### PR TITLE
Deserialize FB content as ErrorResponse when non-200 is returned 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.replyyes</groupId>
   <artifactId>facebook-messenger</artifactId>
-  <version>0.0.4-SNAPSHOT</version>
+  <version>0.0.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.replyyes</groupId>
   <artifactId>facebook-messenger</artifactId>
-  <version>0.0.5-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/replyyes/facebook/messenger/bean/ErrorPayload.java
+++ b/src/main/java/com/replyyes/facebook/messenger/bean/ErrorPayload.java
@@ -1,0 +1,31 @@
+package com.replyyes.facebook.messenger.bean;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+/**
+ * The payload of an {@link ErrorResponse} that gets returned by the Facebook API whenever a message
+ * fails to be sent to a user.
+ *
+ * https://developers.facebook.com/docs/messenger-platform/send-api-reference/errors
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class ErrorPayload {
+    private String message;
+
+    private String type;
+
+    private Long code;
+
+    @JsonProperty("error_subcode")
+    private Long errorSubcode;
+
+    @JsonProperty("fbtrace_id")
+    private String fbtraceId;
+}

--- a/src/main/java/com/replyyes/facebook/messenger/bean/ErrorResponse.java
+++ b/src/main/java/com/replyyes/facebook/messenger/bean/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.replyyes.facebook.messenger.bean;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+
+/**
+ * Represents the response object that is returned from the Facebook API whenever a message
+ * fails to be sent to a user.
+ *
+ * https://developers.facebook.com/docs/messenger-platform/send-api-reference/errors
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ErrorResponse {
+    private ErrorPayload error;
+}

--- a/src/main/java/com/replyyes/facebook/messenger/bean/FacebookMessengerSendException.java
+++ b/src/main/java/com/replyyes/facebook/messenger/bean/FacebookMessengerSendException.java
@@ -1,0 +1,18 @@
+package com.replyyes.facebook.messenger.bean;
+
+import lombok.Getter;
+
+@Getter
+public class FacebookMessengerSendException extends Exception {
+    private static final long serialVersionUID = 5013033180081733121L;
+
+    private final Long errorCode;
+    private final Long errorSubCode;
+
+    public FacebookMessengerSendException(ErrorPayload error) {
+        super(error.getMessage());
+
+        errorCode = error.getCode();
+        errorSubCode = error.getErrorSubcode();
+    }
+}


### PR DESCRIPTION
This will allow callers to have access to the individual error
code/subcode to make decisions on how to handle it (e.g. ignore errors
caused by users not being able to receive messages anymore)